### PR TITLE
Extended support for multiple json sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 *.pyc
+
+.idea/**
+
+/venv/**

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Converts json data from a http url into prometheus metrics using jsonpath
 
 
 ### Config
+ 
+#### For single JSON Endpoint
+
+This syntax is implemented that the old configuration from previous versions do not break.
 
 ```yml
 exporter_port: 9158 # Port on which prometheus can call this exporter to get metrics
@@ -11,12 +15,42 @@ log_level: info
 json_data_url: http://stubonweb.herokuapp.com/kong-cluster-status # Url to get json data used for fetching metric values
 metric_name_prefix: kong_cluster # All metric names will be prefixed with this value
 metrics:
-- name: total_nodes # Final metric name will be kong_cluster_total_nodes
-  description: Total number of nodes in kong cluster
-  path: $.total
-- name: alive_nodes # Final metric name will be kong_cluster_alive_nodes
-  description: Number of live nodes in kong cluster
-  path: count($.data[@.status is "alive"])
+  - name: total_nodes # Final metric name will be kong_cluster_total_nodes
+    description: Total number of nodes in kong cluster
+    path: $.total
+  - name: alive_nodes # Final metric name will be kong_cluster_alive_nodes
+    description: Number of live nodes in kong cluster
+    path: count($.data[@.status is "alive"])
+```
+
+#### For multiple JSON Endpoints
+
+```yml
+exporter_port: 9158 # Port on which prometheus can call this exporter to get metrics
+log_level: info
+endpoints:
+  - json_data_url: http://stubonweb.herokuapp.com/kong-cluster-status # Url to get json data used for fetching metric values
+    metric_name_prefix: kong_cluster_single # All metric names will be prefixed with this value
+    metrics:
+      - name: total_nodes # Final metric name will be kong_cluster_total_nodes
+        description: Total number of nodes in kong cluster
+        path: $.total
+      - name: alive_nodes # Final metric name will be kong_cluster_alive_nodes
+        description: Number of live nodes in kong cluster
+        path: count($.data[@.status is "alive"])
+  - json_data_urls: # OPTIONAL list to configure multiple data URLs separated by tag-label
+      - url: http://stubonweb.herokuapp.com/kong-cluster-status # Url to get json data used for fetching metric values
+        label: kong_cluster_1 # label value for label "tag"
+      - url: http://stubonweb.herokuapp.com/kong-cluster-status # Url to get json data used for fetching metric values
+        label: kong_cluster_2 # label value for label "tag"
+    metric_name_prefix: kong_cluster_multiple # All metric names will be prefixed with this value
+    metrics:
+      - name: total_nodes # Final metric name will be kong_cluster_total_nodes
+        description: Total number of nodes in kong cluster
+        path: $.total
+      - name: alive_nodes # Final metric name will be kong_cluster_alive_nodes
+        description: Number of live nodes in kong cluster
+        path: count($.data[@.status is "alive"])
 ```
 
 See the example below to understand how the json data and metrics will look for this config
@@ -26,7 +60,7 @@ See the example below to understand how the json data and metrics will look for 
 #### Using code (local)
 
 ```
-# Ensure python 2.x and pip installed
+# Ensure python 3.x and pip installed
 pip install -r app/requirements.txt
 python app/exporter.py example/config.yml
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ metrics:
 ```yml
 exporter_port: 9158 # Port on which prometheus can call this exporter to get metrics
 log_level: info
-endpoints:
+endpoints: # you can define multiple endpoints even when they return different structures
   - json_data_url: http://stubonweb.herokuapp.com/kong-cluster-status # Url to get json data used for fetching metric values
     metric_name_prefix: kong_cluster_single # All metric names will be prefixed with this value
     metrics:

--- a/app/exporter.py
+++ b/app/exporter.py
@@ -1,47 +1,67 @@
 #!/usr/bin/python
 
-import json
-import time
-import urllib2
-from prometheus_client import start_http_server
-from prometheus_client.core import GaugeMetricFamily, REGISTRY
 import argparse
+import json
+import logging
+import time
+from urllib.request import urlopen
 import yaml
 from objectpath import Tree
-import logging
+from prometheus_client import start_http_server
+from prometheus_client.core import GaugeMetricFamily, REGISTRY
 
-DEFAULT_PORT=9158
-DEFAULT_LOG_LEVEL='info'
+DEFAULT_PORT = 9158
+DEFAULT_LOG_LEVEL = 'info'
+
 
 class JsonPathCollector(object):
-  def __init__(self, config):
-    self._config = config
+    def __init__(self, config):
+        self._config = config
 
-  def collect(self):
-    config = self._config
-    result = json.loads(urllib2.urlopen(config['json_data_url'], timeout=10).read())
-    result_tree = Tree(result)
-    for metric_config in config['metrics']:
-      metric_name = "{}_{}".format(config['metric_name_prefix'], metric_config['name'])
-      metric_description = metric_config.get('description', '')
-      metric_path = metric_config['path']
-      value = result_tree.execute(metric_path)
-      logging.debug("metric_name: {}, value for '{}' : {}".format(metric_name, metric_path, value))
-      metric = GaugeMetricFamily(metric_name, metric_description, value=value)
-      yield metric
+    def collect(self):
+        config = self._config
+        if 'endpoints' in config:
+            endpoint_list = config['endpoints']
+        else:
+            endpoint_list = [config]
+
+        for endpoint_config in endpoint_list:
+            if 'json_data_url' in endpoint_config:
+                single_data = {"url": endpoint_config['json_data_url']}
+                data_url_list = [single_data]
+            else:
+                data_url_list = endpoint_config['json_data_urls']
+
+            for data_url in data_url_list:
+                result = json.loads(urlopen(data_url['url'], timeout=10).read())
+                result_tree = Tree(result)
+                for metric_config in endpoint_config['metrics']:
+                    metric_name = "{}_{}".format(endpoint_config['metric_name_prefix'], metric_config['name'])
+                    metric_description = metric_config.get('description', '')
+                    metric_path = metric_config['path']
+                    value = result_tree.execute(metric_path)
+                    if "label" in data_url:
+                        logging.debug("metric_name: {}, tag: {}, value for '{}' : {}".format(metric_name, data_url["label"], metric_path, value))
+                        metric = GaugeMetricFamily(metric_name, metric_description, labels=['tag'])
+                        metric.add_metric(labels=[data_url["label"]], value=value)
+                    else:
+                        logging.debug("metric_name: {}, value for '{}' : {}".format(metric_name, metric_path, value))
+                        metric = GaugeMetricFamily(metric_name, metric_description, value=value)
+                    yield metric
 
 
 if __name__ == "__main__":
-  parser = argparse.ArgumentParser(description='Expose metrics bu jsonpath for configured url')
-  parser.add_argument('config_file_path', help='Path of the config file')
-  args = parser.parse_args()
-  with open(args.config_file_path) as config_file:
-    config = yaml.load(config_file)
-    log_level = config.get('log_level', DEFAULT_LOG_LEVEL)
-    logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.getLevelName(log_level.upper()))
-    exporter_port = config.get('exporter_port', DEFAULT_PORT)
-    logging.debug("Config %s", config)
-    logging.info('Starting server on port %s', exporter_port)
-    start_http_server(exporter_port)
-    REGISTRY.register(JsonPathCollector(config))
-  while True: time.sleep(1)
+    parser = argparse.ArgumentParser(description='Expose metrics bu jsonpath for configured url')
+    parser.add_argument('config_file_path', help='Path of the config file')
+    args = parser.parse_args()
+    with open(args.config_file_path) as config_file:
+        config = yaml.load(config_file)
+        log_level = config.get('log_level', DEFAULT_LOG_LEVEL)
+        logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                            level=logging.getLevelName(log_level.upper()))
+        exporter_port = config.get('exporter_port', DEFAULT_PORT)
+        logging.debug("Config %s", config)
+        logging.info('Starting server on port %s', exporter_port)
+        start_http_server(exporter_port)
+        REGISTRY.register(JsonPathCollector(config))
+    while True: time.sleep(1)

--- a/app/exporter.py
+++ b/app/exporter.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     parser.add_argument('config_file_path', help='Path of the config file')
     args = parser.parse_args()
     with open(args.config_file_path) as config_file:
-        config = yaml.load(config_file)
+        config = yaml.load(config_file, Loader=yaml.FullLoader)
         log_level = config.get('log_level', DEFAULT_LOG_LEVEL)
         logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
                             level=logging.getLevelName(log_level.upper()))

--- a/example/config.yml
+++ b/example/config.yml
@@ -1,12 +1,25 @@
-
-exporter_port: 9158 # Port on which prometheu can call this exporter to get metrics
+exporter_port: 9158 # Port on which prometheus can call this exporter to get metrics
 log_level: info
-json_data_url: http://stubonweb.herokuapp.com/kong-cluster-status # Url to get json data used for fetching metric values
-metric_name_prefix: kong_cluster # All metric names will be prefixed with this value
-metrics:
-- name: total_nodes # Final metric name will be kong_cluster_total_nodes
-  description: Total number of nodes in kong cluster
-  path: $.total
-- name: alive_nodes # Final metric name will be kong_cluster_alive_nodes
-  description: Number of live nodes in kong cluster
-  path: count($.data[@.status is "alive"])
+endpoints:
+  - json_data_url: http://stubonweb.herokuapp.com/kong-cluster-status # Url to get json data used for fetching metric values
+    metric_name_prefix: kong_cluster_single # All metric names will be prefixed with this value
+    metrics:
+      - name: total_nodes # Final metric name will be kong_cluster_total_nodes
+        description: Total number of nodes in kong cluster
+        path: $.total
+      - name: alive_nodes # Final metric name will be kong_cluster_alive_nodes
+        description: Number of live nodes in kong cluster
+        path: count($.data[@.status is "alive"])
+  - json_data_urls: # OPTIONAL list to configure multiple data URLs separated by tag-label
+      - url: http://stubonweb.herokuapp.com/kong-cluster-status # Url to get json data used for fetching metric values
+        label: kong_cluster_1 # label value for label "tag"
+      - url: http://stubonweb.herokuapp.com/kong-cluster-status # Url to get json data used for fetching metric values
+        label: kong_cluster_2 # label value for label "tag"
+    metric_name_prefix: kong_cluster_multiple # All metric names will be prefixed with this value
+    metrics:
+      - name: total_nodes # Final metric name will be kong_cluster_total_nodes
+        description: Total number of nodes in kong cluster
+        path: $.total
+      - name: alive_nodes # Final metric name will be kong_cluster_alive_nodes
+        description: Number of live nodes in kong cluster
+        path: count($.data[@.status is "alive"])

--- a/example/config.yml
+++ b/example/config.yml
@@ -1,6 +1,6 @@
 exporter_port: 9158 # Port on which prometheus can call this exporter to get metrics
 log_level: info
-endpoints:
+endpoints:  # you can define multiple endpoints even when they return different structures
   - json_data_url: http://stubonweb.herokuapp.com/kong-cluster-status # Url to get json data used for fetching metric values
     metric_name_prefix: kong_cluster_single # All metric names will be prefixed with this value
     metrics:


### PR DESCRIPTION
- Added support for scrapping the metrics from multiple sources
- Multiple sources can be either be differentiated 
  - by "tag" label (see `json_data_urls` configuration)
  - or metric_name_prefix (see `endpoints` configuration)
- This PR will fix https://github.com/project-sunbird/prometheus-jsonpath-exporter/issues/3